### PR TITLE
Mobile-navigation right-aligned instead of left

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -6,7 +6,7 @@
     {{ site.title }}
   </a>
   <div class="collapse navbar-collapse" id="navbarCollapse">
-    <ul class="nav navbar-nav">
+    <ul class="nav navbar-nav text-right pr-3">
       <li class="nav-item active">
         <a class="nav-link" href="/">
           Home


### PR DESCRIPTION
Also add some padding to the right to make it align a bit better under menu.
<img width="434" alt="screenshot 2017-03-20 13 04 50" src="https://cloud.githubusercontent.com/assets/761483/24114443/3d43c62c-0d6e-11e7-9daf-fd829f72d73f.png">
